### PR TITLE
new ELIP: Confidential Transaction descriptors

### DIFF
--- a/elip-0150.mediawiki
+++ b/elip-0150.mediawiki
@@ -1,5 +1,5 @@
 <pre>
-  ELIP: ????
+  ELIP: 150
   Layer: Wallet
   Title: CT Descriptors for Elements
   Author: Andrew Poelstra <apoelstra@blockstream.com>

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -47,12 +47,14 @@ The current most popular scheme, [https://github.com/satoshilabs/slips/blob/mast
 We propose a new <code>ct</code> descriptor which wraps any other descriptor type in the form <code>ct(<BLINDING_KEY>, <DESCRIPTOR>)</code>.
 Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>elwsh(...)</code> or <code>eltr(...)</code> and <code>BLINDING_KEY</code> is a new expression which must be one of
 * <code>slip77(<64-character hex>)</code> which indicates that blinding keys for these addresses are derived via SLIP77; or
-* <code><KEY></code> which is an ordinary (extended) public key; the blinding key is derived by a Taproot-style tweak of the key with the data of <code><DESCRIPTOR></code>.
+* <code><KEY></code> which is a key expression as described in BIP 380, with the exception that uncompressed and x-only keys are not allowed; the blinding key is derived by a Taproot-style tweak of the key with the data of <code><DESCRIPTOR></code>.
 
 In the <code><KEY></code> expression, all key(s) must be compressed; x-only and uncompressed keys are invalid.
 
 It is permissible, and likely to be common, for a <code><KEY></code> key to be a private key (e.g. an xprv) even if the keys in the actual descriptor are public keys.
 Such a descriptor is termed a '''view descriptor''', and the blinding private key a '''view key'''.
+
+Later extensions to this ELIP may specify alternate expressions for `KEY`, for example to allow MuSig-combining keys from multiple participants.
 
 ===Drawbacks===
 
@@ -95,19 +97,19 @@ Using the <code>ct(slip77(<64-byte hex>), <DESCRIPTOR>)</code> construction, any
 The following CT descriptors should be parseable and generate the given addresses:
 
 * Valid Descriptor 1: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#y0lg3d5y</code>
-** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
 ** Confidential address: <code>CTEnDa5fqGccV3g3jvp4exSQwRfb6FpGchNBF4ZrAaq8ip8gvLqHCtzw1F7d7U5gYJYXBwymgEMmJjca</code>
 ** Unconfidential address: <code>2dhfebpgPWpeqPdCMMam5F2UHAgx3bbLzAg</code>
 * Valid Descriptor 2: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#kt4e25qt</code>
-** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
 ** Confidential address: <code>el1qqg5s7xj7upzl7h4q2k2wj4vq63nvaktn0egqu09nqcr6d44p4evaqknpl78t02k2xqgdh9ltmfmpy9ssk7qfvrldr2dttt3ez</code>
 ** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
 * Valid Descriptor 3: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elsh(wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH)))#xg9r4jej</code>
-** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
 ** Confidential address: <code>AzpnREsN1RSi4JB7rAfpywmPsvGxyygmwm9o3iZcP43svg4frVW5DXvGj5yEx6mKcPtAyHgQWVikFRCM</code>
 ** Unconfidential address: <code>XKGUGskfGsNRR1Ww4ytemgBjuszohUaNgv</code>
 * Valid Descriptor 4: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,eltr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#c0pjjxyw</code>
-** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
 ** Confidential address: <code>el1pq0nsl8du3gsuk7r90sgm78259mmv6mt9d4yvj30zr3u052ufs5meuc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8z2pc847zht4k0</code>
 ** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
 * Valid Descriptor 5: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#hw2glz99</code>
@@ -130,11 +132,11 @@ The following CT descriptors should be parseable and generate the given addresse
 This one is a "view descriptor" which has a private blinding key but otherwise public keys:
 
 * View Descriptor: <code>ct(xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#j95xktq7</code>
-** Blinding private key: <code>xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb</code>
+** Descriptor blinding private key: <code>xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb</code>
 ** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
 ** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
 * Non-view Descriptor: <code>ct(xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#elmfpmp9</code>
-** Blinding public key: <code>xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs</code>
+** Descriptor blinding public key: <code>xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs</code>
 ** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
 ** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -67,7 +67,7 @@ Our scheme uses derived "public" keys (i.e., EC points) to compute private blind
 
 However, this has the following drawbacks:
 * The mismatch between "public" keys being used in a "secret" context may lead to user confusion; though we argue this is no worse than the "secret" chaincode value being included in xpubs used by Bitcoin wallets.
-* Any party who has a copy of an addresses' descriptor is able to see the blinding key and unblind coins sent to that address, or *any* derived address in the case of a non-concrete descriptor.
+* Any party who has a copy of an addresses' descriptor is able to see the blinding key and unblind coins sent to that address, or *any* derived address in the case of a non-derived descriptor (one containing wildcards).
 
 ===Specification===
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -78,11 +78,9 @@ The <code>scriptPubKey</code> corresponding to a <code>ct</code> descriptor is t
 * '''slip77''', encoded as <code>slip77(<64-characters hex>)</code>, whose semantics are that the 64 hex characters are interpreted as the 32-byte <code>master_blinding_key</code> in SLIP77; the <code>scriptPubKey</code> for SLIP77 is computed as normal from the ordinary descriptor.
 These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
 This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
-* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the <code>ordinary descriptor</code>.
-The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code> to hash the following data:
-    * the <code>scriptPubKey</code> of the output, consensus-encoded including its length prefix; followed by
-    * every public key, in 33-byte compressed encoding, concatenated in lexicographic order
-The output of this hash, when interpreted as an integer (most significant byte first) modulo the group order, is the blinding ''private'' key. If this hash is zero, the resulting descriptor is invalid.
+* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the <code>ordinary descriptor</code>. The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code> to hash the following data:
+** the <code>scriptPubKey</code> of the output, consensus-encoded including its length prefix; followed by
+** every public key, in 33-byte compressed encoding, concatenated in lexicographic order The output of this hash, when interpreted as an integer (most significant byte first) modulo the group order, is the blinding ''private'' key. If this hash is zero, the resulting descriptor is invalid.
 * '''bare key''', which simply encodes a single key in the same way as the keys in <code>ordinary descriptor</code> are encoded.
 This may be a private or public key; its public key is used as the blinding key for the address. 
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -86,11 +86,80 @@ In other words, users of this variant will be unable to provide external parties
 
 In a future ELIP we will specify a standard deterministic key generation scheme for this case.
 
-==Security==
-
 ==Backwards Compatibility==
 
 Using the <code>ct(slip77(<64-byte hex>), <DESCRIPTOR>)</code> construction, any wallet should be able to express its existing confidential addresses using this new scheme.
+
+==Test Vectors==
+
+The following CT descriptors should be parseable and generate the given addresses:
+
+* Valid Descriptor 1: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#y0lg3d5y</code>
+** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Confidential address: <code>CTEnDa5fqGccV3g3jvp4exSQwRfb6FpGchNBF4ZrAaq8ip8gvLqHCtzw1F7d7U5gYJYXBwymgEMmJjca</code>
+** Unconfidential address: <code>2dhfebpgPWpeqPdCMMam5F2UHAgx3bbLzAg</code>
+* Valid Descriptor 2: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#kt4e25qt</code>
+** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Confidential address: <code>el1qqg5s7xj7upzl7h4q2k2wj4vq63nvaktn0egqu09nqcr6d44p4evaqknpl78t02k2xqgdh9ltmfmpy9ssk7qfvrldr2dttt3ez</code>
+** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+* Valid Descriptor 3: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elsh(wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH)))#xg9r4jej</code>
+** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Confidential address: <code>AzpnREsN1RSi4JB7rAfpywmPsvGxyygmwm9o3iZcP43svg4frVW5DXvGj5yEx6mKcPtAyHgQWVikFRCM</code>
+** Unconfidential address: <code>XKGUGskfGsNRR1Ww4ytemgBjuszohUaNgv</code>
+* Valid Descriptor 4: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,eltr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#c0pjjxyw</code>
+** Blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
+** Confidential address: <code>el1pq0nsl8du3gsuk7r90sgm78259mmv6mt9d4yvj30zr3u052ufs5meuc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8z2pc847zht4k0</code>
+** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
+* Valid Descriptor 5: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#hw2glz99</code>
+** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
+** Confidential address: <code>CTEvn67jjJXDr3aDCZypTCJc6XHZ7ATyd89oXfNLQt1G2omPUpPkHA6zUAGPGF2YH4RnWfWut2f4dRSd</code>
+** Unconfidential address: <code>2dhfebpgPWpeqPdCMMam5F2UHAgx3bbLzAg</code>
+* Valid Descriptor 6: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#545pl285</code>
+** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
+** Confidential address: <code>el1qqdx5wnttttzulcs6ujlg9pfts6mp3r4sdwg5ekdej566n5wxzk88vknpl78t02k2xqgdh9ltmfmpy9ssk7qfvge347y58xukt</code>
+** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+* Valid Descriptor 7: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elsh(wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH)))#m30vswxr</code>
+** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
+** Confidential address: <code>AzptgrWR3xVX6Qg8mbkyZiESb6C9uy8VCUdCCmw7UtceiF5H8PdB6933YDT7vHsevK1yFmxfajdaedCH</code>
+** Unconfidential address: <code>XKGUGskfGsNRR1Ww4ytemgBjuszohUaNgv</code>
+* Valid Descriptor 8: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),eltr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#n3v4t5cs</code>
+** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
+** Confidential address: <code>el1pq26fndnz8ef6umlz6e2755sm6j5jwxv3tdt2295mr4mx6ux0uf8vcc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8zwzhhycxfhdrm</code>
+** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
+
+This one is a "view descriptor" which has a private blinding key but otherwise public keys:
+
+* View Descriptor: <code>ct(xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#j95xktq7</code>
+** Blinding private key: <code>xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb</code>
+** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
+** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+* Non-view Descriptor: <code>ct(xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#elmfpmp9</code>
+** Blinding public key: <code>xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs</code>
+** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
+** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+
+The non-view descriptor is the same as the view descriptor except that its private blinding key has been replaced with a public key. Notice that the generated addresses are the same in both cases.
+
+Finally, the following are invalid test vectors that should not be parseable:
+
+* Invalid Descriptor 1
+** <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elsh(wpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4)))#xxxxxxxx</code>
+** Reason: Invalid checksum 'xxxxxxxx', expected 'qgjmm4as'
+* Invalid Descriptor 2
+** <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04,b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elsh(wpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4)))#qs64ccxw</code>
+** Reason: slip77() must have exactly one argument, not 2
+* Invalid Descriptor 3
+** <code>ct(slip77,elsh(wpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4)))#8p3zmumf</code>
+** Reason: slip77() must have exactly one argument, not 0
+* Invalid Descriptor 4
+** <code>ct(elsh(wpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4)))#u9cwz9f3</code>
+** Reason: CT descriptor had 1 arguments rather than 2 (no blinding key)
+* Invalid Descriptor 5
+** <code>ct(02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623,02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623,elwpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4))#cnsp2qsc</code>
+** Reason: CT descriptor had 3 arguments rather than 2 (extra data)
+* Invalid Descriptor 6
+** <code>ct(pk(02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623),elwpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4))#nvax6rau</code>
+** Reason: first argument is a pk descriptor, not a blinding key
 
 ==Acknowledgements==
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -50,6 +50,8 @@ Here `DESCRIPTOR` refers to any existing descriptor, e.g. `wsh(...)` or `tr(...)
 * `hash_to_private(<KEY_1>, <KEY_2>, ...)` which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
 * `<KEY>` which is an ordinary (extended) public key which will be used as a blinding key
 
+In both the `hash_to_private` and `<KEY>` expressions, all keys must be compressed; x-only and uncompressed keys are invalid.
+
 We note that even if the descriptor includes private keys, as it will when used for wallet backups, the keys included in the `hash_to_private` combinator will be converted to public keys before sorting and hashing.
 
 We further note that even single-party wallets are likely to use the `hash_to_private()` adaptor rather than directly using `<key>`.

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -49,7 +49,7 @@ Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>elwsh
 * <code>slip77(<64-character hex>)</code> which indicates that blinding keys for these addresses are derived via SLIP77; or
 * <code><KEY></code> which is an ordinary (extended) public key; the blinding key is derived by a Taproot-style tweak of the key with the data of <code><DESCRIPTOR></code>.
 
-In both the <code><KEY></code> expression, all key(s) must be compressed; x-only and uncompressed keys are invalid.
+In the <code><KEY></code> expression, all key(s) must be compressed; x-only and uncompressed keys are invalid.
 
 It is permissible, and likely to be common, for a <code><KEY></code> key to be a private key (e.g. an xprv) even if the keys in the actual descriptor are public keys.
 Such a descriptor is termed a '''view descriptor''', and the blinding private key a '''view key'''.
@@ -71,7 +71,7 @@ The <code>scriptPubKey</code> corresponding to a <code>ct</code> descriptor is t
 * '''slip77''', encoded as <code>slip77(<64-characters hex>)</code>, whose semantics are that the 64 hex characters are interpreted as the 32-byte <code>master_blinding_key</code> in SLIP77; the <code>scriptPubKey</code> for SLIP77 is computed as normal from the ordinary descriptor.
 ** These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
 ** This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
-* '''bare key''', which simply encodes a single key in the same way as the keys in <code>ordinary descriptor</code> are encoded. The blinding key is derived from the address hy taking the public key ''K'' and tweaking it to form a new key ''K<sub>blind</sub>'' as follows:
+* '''bare key''', which simply encodes a single key in the same way as the keys in <code><DESCRIPTOR></code> are encoded. The blinding key is derived from the address by taking the public key ''K'' and tweaking it to form a new key ''K<sub>blind</sub>'' as follows:
 ** ''K' = K + H<sub>tag</sub>(K, <code>scriptPubKey</code>)'', where
 ** ''H<sub>tag</sub>'' is a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code>;
 ** the comma indicates concatenation;

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -128,6 +128,10 @@ The following CT descriptors should be parseable and generate the given addresse
 ** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
 ** Confidential address: <code>el1pq26fndnz8ef6umlz6e2755sm6j5jwxv3tdt2295mr4mx6ux0uf8vcc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8zwzhhycxfhdrm</code>
 ** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
+* Valid Descriptor 9: <code>ct(02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623,elwpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4))#h5e0p6m9</code>
+** Blinding key: <code>02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623</code>
+** Confidential address: <code>el1qq0r6pegudzm0tzpszelc34qjln4fdxawgwmgnza63wwpzdy6jrm0grmqvvk2ce5ksnxcs9ecgtnryt7xg34060uctupg60d02</code>
+** Unconfidential address: <code>ert1qpasxxt9vv6tgfnvgzuuy9e3j9lryg6ha53x9q0</code>
 
 This one is a "view descriptor" which has a private blinding key but otherwise public keys:
 
@@ -141,6 +145,18 @@ This one is a "view descriptor" which has a private blinding key but otherwise p
 ** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
 
 The non-view descriptor is the same as the view descriptor except that its private blinding key has been replaced with a public key. Notice that the generated addresses are the same in both cases.
+
+This one is a "view descriptor" using ordinary keys rather than extended ones:
+
+* View Descriptor 2: <code>ct(L3jXxwef3fpB7hcrFozcWgHeJCPSAFiZ1Ji2YJMPxceaGvy3PC1q,elwpkh(021a8fb6bd5a653b021b98a2a785725b8ddacfe3687bc043aa7f4d25d3a48d40b5))#stngzuwt</code>
+** Descriptor blinding private key: <code>L3jXxwef3fpB7hcrFozcWgHeJCPSAFiZ1Ji2YJMPxceaGvy3PC1q</code>
+** Confidential address: <code>el1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfyqwa4jj40uffq</code>
+** Unconfidential address: <code>ert1qklrycvkecdanpcpyulgz3c8udvxyck5jkzxddw</code>
+
+* Non-view Descriptor 2: <code>ct(0286fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90,elwpkh(021a8fb6bd5a653b021b98a2a785725b8ddacfe3687bc043aa7f4d25d3a48d40b5))#m5mvyh29</code>
+** Descriptor blinding public key: <code>0286fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90</code>
+** Confidential address: <code>el1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfyqwa4jj40uffq</code>
+** Unconfidential address: <code>ert1qklrycvkecdanpcpyulgz3c8udvxyck5jkzxddw</code>
 
 Finally, the following are invalid test vectors that should not be parseable:
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -1,0 +1,96 @@
+<pre>
+  ELIP: ????
+  Layer: Wallet
+  Title: CT Descriptors for Elements
+  Author: Andrew Poelstra <apoelstra@blockstream.com>
+          Tim Ruffing <crypto@timruffing.de>
+  Comments-Summary: No comments yet.
+  Comments-URI: https://github.com/ElementsProject/elips/wiki/Comments:ELIP-????
+  Status: Draft
+  Type: Standards Track
+  Created: 2022-10-06
+  License: BSD-3-Clause
+</pre>
+
+==Introduction==
+
+===Abstract===
+
+This document proposes a new wrapper around existing and future Elements descriptor types, which allows attaching a confidential blinding key to an ordinary output script descriptor. It introduces new syntax to support both existing SLIP77-style confidential keys as well as a new, more flexible style.
+
+===Copyright===
+
+This document is licensed under the 3-clause BSD license.
+
+===Motivation===
+
+Confidential Transactions involve the use of uniformly random "blinding factors" associated to every confidential output.
+These random values are secret, but must be known by the sender (in order to construct a transaction) as well as recipient (in order to recognize the received assets and amounts, and to spend the outputs).
+This means they must be chosen by the sender of a transaction and somehow securely communicated to the recipient.
+
+The way this is done is that confidential addresses contain the public key of an extra "blinding key" pair created by the recipient.
+When blinding, the sender chooses a fresh EC Diffie-Hellman (ECDH) private key, encodes the corresponding public key in the "nonce" field of the transaction, derives an ECDH secret between the fresh private key and the public blinding key, uses the ECDH secret to encrypt the blinding factors for the output, and encodes the encrypted result in the rangeproof.
+The recipient, when recognizing a scriptPubKey corresponding to the ordinary part of her confidential address, uses the private blinding key for that address in conjunction with the nonce field of the txout to re-derive the ECDH secret and decrypt the blinding factors.
+
+This document defines a standard way for the recipient's wallet to compute blinding key pairs. There are a number of requirements:
+
+* Confidential addresses, including their attached blinding key, should be derivable from a single descriptor without extra data
+* Wallets should be able to choose the granularity of their blinding keys, so that the revelation of private blinding keys may unblind one, a subset, or all, of its blinded outputs
+* In multiparty settings, each wallet should be able to restrict this granularity
+* It should be possible somehow to do public derivation of CT addresses, given only a descriptor containing (extended) public keys
+
+The current most popular scheme, [https://github.com/satoshilabs/slips/blob/master/slip-0077.md SLIP-77], does not satisfy any of these criteria, which limits its usefulness as we move toward a descriptor-centric setting in which multiparty addresses are common.
+
+==Design==
+
+===Overview===
+We propose a new `ct` descriptor which wraps any other descriptor type in the form `ct(<BLINDING_KEY>, <DESCRIPTOR>)`.
+Here `DESCRIPTOR` refers to any existing descriptor, e.g. `wsh(...)` or `tr(...)` and `BLINDING_KEY` is a new expression which must be one of
+* `slip77(<64-character hex>)` which indicates that blinding keys for these addresses are derived via SLIP77; or
+* `hash_to_private(<KEY_1>, <KEY_2>, ...)` which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
+* `<KEY>` which is an ordinary (extended) public key which will be used as a blinding key
+
+We note that even if the descriptor includes private keys, as it will when used for wallet backups, the keys included in the `hash_to_private` combinator will be converted to public keys before sorting and hashing.
+
+We further note that even single-party wallets are likely to use the `hash_to_private()` adaptor rather than directly using `<key>`.
+The reason is that decrypting rangeproofs requires the private key corresponding to `<key>`, which likely means that decryption happens on a hardware wallet.
+Since decryption is as computationally complex as verifying a rangeproof, we do not expect common wallets to support it directly.
+This form of descriptor may become more common post-Bulletproofs, when we will make decryption much easier.
+
+===Drawbacks===
+
+Our scheme uses derived "public" keys (i.e., EC points) to compute private blinding keys, because
+* Many hardware wallets are incapable of producing rangeproofs, which require significant memory and processing power, but they will not reveal private keys to the host computer, only public keys;
+* Public keys alone cannot be used for multiparty addresses, since we require that each individual participant be able to unblind confidential outputs sent to a multiparty address.
+
+However, this has the following drawbacks:
+* The mismatch between "public" keys being used in a "secret" context may lead to user confusion; though we argue this is no worse than the "secret" chaincode value being included in xpubs used by Bitcoin wallets.
+* Any party who has a copy of an addresses' descriptor is able to see the blinding key and unblind coins sent to that address, or *any* derived address in the case of a non-concrete descriptor.
+
+===Specification===
+
+First, the `ct` descriptor is defined as above: its string serialization is given by `ct(<BLINDING_KEY>, <DESCRIPTOR>)` where `DESCRIPTOR` is the string serialization of an ordinary descriptor.
+The `scriptPubKey` corresponding to a `ct` descriptor is that corresponding to the embedded `DESCRIPTOR`. The encoding and semantics of `BLINDING_KEY` are given below.
+
+`BLINDING_KEY` expressions are one of
+* '''slip77''', encoded as `slip77(<64-characters hex>)`, whose semantics are that the 64 hex characters are interpreted as the 32-byte `master_blinding_key` in SLIP77; the `scriptPubKey` for SLIP77 is computed as normal from the ordinary descriptor.
+These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
+This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
+* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the `ordinary descriptor`.
+The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag `CT-Blinding-Key/1.0` to hash the following data:
+    * the `scriptPubKey` of the output, consensus-encoded including its length prefix; followed by
+    * every public key, in 33-byte compressed encoding, concatenated in lexicographic order
+The output of this hash, when interpreted as an integer (most significant byte first) modulo the group order, is the blinding ''private'' key. If this hash is zero, the resulting descriptor is invalid.
+* '''bare key''', which simply encodes a single key in the same way as the keys in `ordinary descriptor` are encoded.
+This may be a private or public key; its public key is used as the blinding key for the address. 
+
+==Security==
+
+==Backwards Compatibility==
+
+Using the `ct(slip77(<64-byte hex>), <DESCRIPTOR>)` construction, any wallet should be able to express its existing confidential addresses using this new scheme.
+
+==Acknowledgements==
+
+We would like to thank Leo Comandini for describing practical requirements by wallet authors, and to Jonas Nick for providing feedback on the cryptographic design.
+

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -45,7 +45,7 @@ The current most popular scheme, [https://github.com/satoshilabs/slips/blob/mast
 
 ===Overview===
 We propose a new <code>ct</code> descriptor which wraps any other descriptor type in the form <code>ct(<BLINDING_KEY>, <DESCRIPTOR>)</code>.
-Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>wsh(...)</code> or <code>tr(...)</code> and <code>BLINDING_KEY</code> is a new expression which must be one of
+Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>elwsh(...)</code> or <code>eltr(...)</code> and <code>BLINDING_KEY</code> is a new expression which must be one of
 * <code>slip77(<64-character hex>)</code> which indicates that blinding keys for these addresses are derived via SLIP77; or
 * <code>hash_to_private(<KEY_1>, <KEY_2>, ...)</code> which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
 * <code><KEY></code> which is an ordinary (extended) public key which will be used as a blinding key

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -47,27 +47,20 @@ The current most popular scheme, [https://github.com/satoshilabs/slips/blob/mast
 We propose a new <code>ct</code> descriptor which wraps any other descriptor type in the form <code>ct(<BLINDING_KEY>, <DESCRIPTOR>)</code>.
 Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>elwsh(...)</code> or <code>eltr(...)</code> and <code>BLINDING_KEY</code> is a new expression which must be one of
 * <code>slip77(<64-character hex>)</code> which indicates that blinding keys for these addresses are derived via SLIP77; or
-* <code>hash_to_private(<KEY_1>, <KEY_2>, ...)</code> which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
-* <code><KEY></code> which is an ordinary (extended) public key which will be used as a blinding key
+* <code><KEY></code> which is an ordinary (extended) public key; the blinding key is derived by a Taproot-style tweak of the key with the data of <code><DESCRIPTOR></code>.
 
-In both the <code>hash_to_private</code> and <code><KEY></code> expressions, all keys must be compressed; x-only and uncompressed keys are invalid.
+In both the <code><KEY></code> expression, all key(s) must be compressed; x-only and uncompressed keys are invalid.
 
-We note that even if the descriptor includes private keys, as it will when used for wallet backups, the keys included in the <code>hash_to_private</code> combinator will be converted to public keys before sorting and hashing.
-
-We further note that even single-party wallets are likely to use the <code>hash_to_private()</code> adaptor rather than directly using <code><key></code>.
-The reason is that decrypting rangeproofs requires the private key corresponding to <code><key></code>, which likely means that decryption happens on a hardware wallet.
-Since decryption is as computationally complex as verifying a rangeproof, we do not expect common wallets to support it directly.
-This form of descriptor may become more common post-Bulletproofs, when we will make decryption much easier.
+It is permissible, and likely to be common, for a <code><KEY></code> key to be a private key (e.g. an xprv) even if the keys in the actual descriptor are public keys.
+Such a descriptor is termed a '''view descriptor''', and the blinding private key a '''view key'''.
 
 ===Drawbacks===
 
-Our scheme uses derived "public" keys (i.e., EC points) to compute private blinding keys, because
-* Many hardware wallets are incapable of producing rangeproofs, which require significant memory and processing power, but they will not reveal private keys to the host computer, only public keys;
-* Public keys alone cannot be used for multiparty addresses, since we require that each individual participant be able to unblind confidential outputs sent to a multiparty address.
+* Because there is no sensible way to do multiparty unblinding, the blinding key must be a single key whose private half is known to all participants.
+* The use of "view descriptors" which are nominally public but contain secret key data, may lead to user confusion; though we argue it has similar privacy properties to the chaincode value included in xpubs.
+* Any party who has a copy of an addresses' view descriptor is able to see the blinding key and unblind coins sent to that address, or *any* derived address in the case of a descriptor containing wildcards.
 
-However, this has the following drawbacks:
-* The mismatch between "public" keys being used in a "secret" context may lead to user confusion; though we argue this is no worse than the "secret" chaincode value being included in xpubs used by Bitcoin wallets.
-* Any party who has a copy of an addresses' descriptor is able to see the blinding key and unblind coins sent to that address, or *any* derived address in the case of a non-derived descriptor (one containing wildcards).
+The latter point is the intended use of view descriptors, and is listed as a drawback only because it may be surprising.
 
 ===Specification===
 
@@ -76,13 +69,22 @@ The <code>scriptPubKey</code> corresponding to a <code>ct</code> descriptor is t
 
 <code>BLINDING_KEY</code> expressions are one of
 * '''slip77''', encoded as <code>slip77(<64-characters hex>)</code>, whose semantics are that the 64 hex characters are interpreted as the 32-byte <code>master_blinding_key</code> in SLIP77; the <code>scriptPubKey</code> for SLIP77 is computed as normal from the ordinary descriptor.
-These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
-This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
-* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the <code>ordinary descriptor</code>. The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code> to hash the following data:
-** the <code>scriptPubKey</code> of the output, consensus-encoded including its length prefix; followed by
-** every public key, in 33-byte compressed encoding, concatenated in lexicographic order The output of this hash, when interpreted as an integer (most significant byte first) modulo the group order, is the blinding ''private'' key. If this hash is zero, the resulting descriptor is invalid.
-* '''bare key''', which simply encodes a single key in the same way as the keys in <code>ordinary descriptor</code> are encoded.
-This may be a private or public key; its public key is used as the blinding key for the address. 
+** These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
+** This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
+* '''bare key''', which simply encodes a single key in the same way as the keys in <code>ordinary descriptor</code> are encoded. The blinding key is derived from the address hy taking the public key ''K'' and tweaking it to form a new key ''K<sub>blind</sub>'' as follows:
+** ''K' = K + H<sub>tag</sub>(K, <code>scriptPubKey</code>)'', where
+** ''H<sub>tag</sub>'' is a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code>;
+** the comma indicates concatenation;
+** and <code>scriptPubKey</code> is the scriptPubKey of the output, consensus-encoded including its length prefix.
+
+Because the scriptPubKey is revealed on the blockchain, its role in the tagged hash is merely to ensure that blinding keys are not reused across multiple outputs, unless they are identical (in which case the reuse amounts to ordinary address reuse).
+Privacy and security are provided by the untweaked key ''K'', which is never revealed on-chain.
+
+In some circumstances, it may make sense for ''K'' to be derived deterministically from the descriptor data, rather than being chosen and specified separately.
+This reduces implementation complexity and the need to store additional keys, at the cost of turning the descriptor unconditionally into a view descriptor.
+In other words, users of this variant will be unable to provide external parties the ability to derive addresses without ''also'' providing them the ability to unblind coins.
+
+In a future ELIP we will specify a standard deterministic key generation scheme for this case.
 
 ==Security==
 

--- a/elip-ct-descriptors.mediawiki
+++ b/elip-ct-descriptors.mediawiki
@@ -44,18 +44,18 @@ The current most popular scheme, [https://github.com/satoshilabs/slips/blob/mast
 ==Design==
 
 ===Overview===
-We propose a new `ct` descriptor which wraps any other descriptor type in the form `ct(<BLINDING_KEY>, <DESCRIPTOR>)`.
-Here `DESCRIPTOR` refers to any existing descriptor, e.g. `wsh(...)` or `tr(...)` and `BLINDING_KEY` is a new expression which must be one of
-* `slip77(<64-character hex>)` which indicates that blinding keys for these addresses are derived via SLIP77; or
-* `hash_to_private(<KEY_1>, <KEY_2>, ...)` which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
-* `<KEY>` which is an ordinary (extended) public key which will be used as a blinding key
+We propose a new <code>ct</code> descriptor which wraps any other descriptor type in the form <code>ct(<BLINDING_KEY>, <DESCRIPTOR>)</code>.
+Here <code>DESCRIPTOR</code> refers to any existing descriptor, e.g. <code>wsh(...)</code> or <code>tr(...)</code> and <code>BLINDING_KEY</code> is a new expression which must be one of
+* <code>slip77(<64-character hex>)</code> which indicates that blinding keys for these addresses are derived via SLIP77; or
+* <code>hash_to_private(<KEY_1>, <KEY_2>, ...)</code> which indicates that the blinding key is produced by a hash of the sorted list of one or more public keys; or
+* <code><KEY></code> which is an ordinary (extended) public key which will be used as a blinding key
 
-In both the `hash_to_private` and `<KEY>` expressions, all keys must be compressed; x-only and uncompressed keys are invalid.
+In both the <code>hash_to_private</code> and <code><KEY></code> expressions, all keys must be compressed; x-only and uncompressed keys are invalid.
 
-We note that even if the descriptor includes private keys, as it will when used for wallet backups, the keys included in the `hash_to_private` combinator will be converted to public keys before sorting and hashing.
+We note that even if the descriptor includes private keys, as it will when used for wallet backups, the keys included in the <code>hash_to_private</code> combinator will be converted to public keys before sorting and hashing.
 
-We further note that even single-party wallets are likely to use the `hash_to_private()` adaptor rather than directly using `<key>`.
-The reason is that decrypting rangeproofs requires the private key corresponding to `<key>`, which likely means that decryption happens on a hardware wallet.
+We further note that even single-party wallets are likely to use the <code>hash_to_private()</code> adaptor rather than directly using <code><key></code>.
+The reason is that decrypting rangeproofs requires the private key corresponding to <code><key></code>, which likely means that decryption happens on a hardware wallet.
 Since decryption is as computationally complex as verifying a rangeproof, we do not expect common wallets to support it directly.
 This form of descriptor may become more common post-Bulletproofs, when we will make decryption much easier.
 
@@ -71,26 +71,26 @@ However, this has the following drawbacks:
 
 ===Specification===
 
-First, the `ct` descriptor is defined as above: its string serialization is given by `ct(<BLINDING_KEY>, <DESCRIPTOR>)` where `DESCRIPTOR` is the string serialization of an ordinary descriptor.
-The `scriptPubKey` corresponding to a `ct` descriptor is that corresponding to the embedded `DESCRIPTOR`. The encoding and semantics of `BLINDING_KEY` are given below.
+First, the <code>ct</code> descriptor is defined as above: its string serialization is given by <code>ct(<BLINDING_KEY>, <DESCRIPTOR>)</code> where <code>DESCRIPTOR</code> is the string serialization of an ordinary descriptor.
+The <code>scriptPubKey</code> corresponding to a <code>ct</code> descriptor is that corresponding to the embedded <code>DESCRIPTOR</code>. The encoding and semantics of <code>BLINDING_KEY</code> are given below.
 
-`BLINDING_KEY` expressions are one of
-* '''slip77''', encoded as `slip77(<64-characters hex>)`, whose semantics are that the 64 hex characters are interpreted as the 32-byte `master_blinding_key` in SLIP77; the `scriptPubKey` for SLIP77 is computed as normal from the ordinary descriptor.
+<code>BLINDING_KEY</code> expressions are one of
+* '''slip77''', encoded as <code>slip77(<64-characters hex>)</code>, whose semantics are that the 64 hex characters are interpreted as the 32-byte <code>master_blinding_key</code> in SLIP77; the <code>scriptPubKey</code> for SLIP77 is computed as normal from the ordinary descriptor.
 These 32 bytes are the same for both public and private descriptors; they have no "public" equivalent.
 This mode is not recommended because there is no way to express this descriptor without revealing the SLIP77 key, which can be used to unblind every single output received by the wallet.
-* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the `ordinary descriptor`.
-The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag `CT-Blinding-Key/1.0` to hash the following data:
-    * the `scriptPubKey` of the output, consensus-encoded including its length prefix; followed by
+* '''hash_to_private''' takes a list of public or private keys, encoded identically to the keys in the <code>ordinary descriptor</code>.
+The semantics are to use a [https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#Design BIP-340 tagged hash] with tag <code>CT-Blinding-Key/1.0</code> to hash the following data:
+    * the <code>scriptPubKey</code> of the output, consensus-encoded including its length prefix; followed by
     * every public key, in 33-byte compressed encoding, concatenated in lexicographic order
 The output of this hash, when interpreted as an integer (most significant byte first) modulo the group order, is the blinding ''private'' key. If this hash is zero, the resulting descriptor is invalid.
-* '''bare key''', which simply encodes a single key in the same way as the keys in `ordinary descriptor` are encoded.
+* '''bare key''', which simply encodes a single key in the same way as the keys in <code>ordinary descriptor</code> are encoded.
 This may be a private or public key; its public key is used as the blinding key for the address. 
 
 ==Security==
 
 ==Backwards Compatibility==
 
-Using the `ct(slip77(<64-byte hex>), <DESCRIPTOR>)` construction, any wallet should be able to express its existing confidential addresses using this new scheme.
+Using the <code>ct(slip77(<64-byte hex>), <DESCRIPTOR>)</code> construction, any wallet should be able to express its existing confidential addresses using this new scheme.
 
 ==Acknowledgements==
 


### PR DESCRIPTION
This ELIP describes CT descriptors, as needed to attach blinding keys to existing descriptors and therefore create confidential addresses.

It does not cover:

* Ordinary Elements descriptors, e.g. eltr; these need a separate standard preceding this one
* Pegins or pegouts
* Anything related to PAK keys

Dupliicate of #1 created because of Github bugs.