### PR TITLE
elip150/151: test vectors: generate mainnet addresses

### DIFF
--- a/elip-0150.mediawiki
+++ b/elip-0150.mediawiki
@@ -99,51 +99,51 @@ The following CT descriptors should be parseable and generate the given addresse
 
 * Valid Descriptor 1: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#y0lg3d5y</code>
 ** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
-** Confidential address: <code>CTEnDa5fqGccV3g3jvp4exSQwRfb6FpGchNBF4ZrAaq8ip8gvLqHCtzw1F7d7U5gYJYXBwymgEMmJjca</code>
-** Unconfidential address: <code>2dhfebpgPWpeqPdCMMam5F2UHAgx3bbLzAg</code>
+** Confidential address: <code>VTpvZZYdbhbyVF3Wa99eMjgXhfvu4LS26dR2FwMfNXq7FDX73HZEsZr3VvgH9EDgQnYK7sP6ACKSuMGw</code>
+** Unconfidential address: <code>Q5WHLVd78iAspUNvzuULvi2F8u693pzAqe</code>
 * Valid Descriptor 2: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#kt4e25qt</code>
 ** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
-** Confidential address: <code>el1qqg5s7xj7upzl7h4q2k2wj4vq63nvaktn0egqu09nqcr6d44p4evaqknpl78t02k2xqgdh9ltmfmpy9ssk7qfvrldr2dttt3ez</code>
-** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+** Confidential address: <code>lq1qqg5s7xj7upzl7h4q2k2wj4vq63nvaktn0egqu09nqcr6d44p4evaqknpl78t02k2xqgdh9ltmfmpy9ssk7qfvghdsfr4mvr9c</code>
+** Unconfidential address: <code>ex1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyktcafre</code>
 * Valid Descriptor 3: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,elsh(wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH)))#xg9r4jej</code>
 ** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
-** Confidential address: <code>AzpnREsN1RSi4JB7rAfpywmPsvGxyygmwm9o3iZcP43svg4frVW5DXvGj5yEx6mKcPtAyHgQWVikFRCM</code>
-** Unconfidential address: <code>XKGUGskfGsNRR1Ww4ytemgBjuszohUaNgv</code>
+** Confidential address: <code>VJL8znN4XjXEUKzDaYsqdzRASGLY2KHxC4N6g5b5QvrNjXfeKp83Ci9AW2a8QzbZjpEffoy4PEywpLAZ</code>
+** Unconfidential address: <code>Gq6kpy2HiNgsyQVpBsuBKAPRFiir23qKro</code>
 * Valid Descriptor 4: <code>ct(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,eltr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#c0pjjxyw</code>
 ** Descriptor blinding public key: <code>xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL</code>
-** Confidential address: <code>el1pq0nsl8du3gsuk7r90sgm78259mmv6mt9d4yvj30zr3u052ufs5meuc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8z2pc847zht4k0</code>
-** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
+** Confidential address: <code>lq1pq0nsl8du3gsuk7r90sgm78259mmv6mt9d4yvj30zr3u052ufs5meuc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8zrdxdfgp8g9pl</code>
+** Unconfidential address: <code>ex1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3qxa9kvf</code>
 * Valid Descriptor 5: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#hw2glz99</code>
 ** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
-** Confidential address: <code>CTEvn67jjJXDr3aDCZypTCJc6XHZ7ATyd89oXfNLQt1G2omPUpPkHA6zUAGPGF2YH4RnWfWut2f4dRSd</code>
-** Unconfidential address: <code>2dhfebpgPWpeqPdCMMam5F2UHAgx3bbLzAg</code>
+** Confidential address: <code>VTq585ahVjWarEwg2nKQ9yYirmYs5F5j74CeYYA9cq1EZD9obm7hwpx6xqq3J1AY9YRaSavEMzYfr6t7</code>
+** Unconfidential address: <code>Q5WHLVd78iAspUNvzuULvi2F8u693pzAqe</code>
 * Valid Descriptor 6: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#545pl285</code>
 ** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
-** Confidential address: <code>el1qqdx5wnttttzulcs6ujlg9pfts6mp3r4sdwg5ekdej566n5wxzk88vknpl78t02k2xqgdh9ltmfmpy9ssk7qfvge347y58xukt</code>
-** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+** Confidential address: <code>lq1qqdx5wnttttzulcs6ujlg9pfts6mp3r4sdwg5ekdej566n5wxzk88vknpl78t02k2xqgdh9ltmfmpy9ssk7qfvr33xa22hpw23</code>
+** Unconfidential address: <code>ex1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyktcafre</code>
 * Valid Descriptor 7: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),elsh(wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH)))#m30vswxr</code>
 ** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
-** Confidential address: <code>AzptgrWR3xVX6Qg8mbkyZiESb6C9uy8VCUdCCmw7UtceiF5H8PdB6933YDT7vHsevK1yFmxfajdaedCH</code>
-** Unconfidential address: <code>XKGUGskfGsNRR1Ww4ytemgBjuszohUaNgv</code>
+** Confidential address: <code>VJLFGQ17aGa3WSVEVyxzDktD9SFixJjfSmqVq8xaWmR9X6gFbiF95KFwKA41PBhu3jNTxJFKTUphHL8J</code>
+** Unconfidential address: <code>Gq6kpy2HiNgsyQVpBsuBKAPRFiir23qKro</code>
 * Valid Descriptor 8: <code>ct(slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),eltr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#n3v4t5cs</code>
 ** SLIP77 master blinding key: <code>b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04</code>
-** Confidential address: <code>el1pq26fndnz8ef6umlz6e2755sm6j5jwxv3tdt2295mr4mx6ux0uf8vcc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8zwzhhycxfhdrm</code>
-** Unconfidential address: <code>ert1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3q3s6527</code>
+** Confidential address: <code>lq1pq26fndnz8ef6umlz6e2755sm6j5jwxv3tdt2295mr4mx6ux0uf8vcc2tuvwx7k7g9kvhhpux07vqpm3qjj8uwdj94650265ustv0xy8z8wfacw9e5a5t</code>
+** Unconfidential address: <code>ex1pv997x8r0t0yzmxtms7r8lxqqacsffr78xez6a284d2wg9k8nzr3qxa9kvf</code>
 * Valid Descriptor 9: <code>ct(02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623,elwpkh(03774eec7a3d550d18e9f89414152025b3b0ad6a342b19481f702d843cff06dfc4))#h5e0p6m9</code>
 ** Blinding key: <code>02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623</code>
-** Confidential address: <code>el1qq0r6pegudzm0tzpszelc34qjln4fdxawgwmgnza63wwpzdy6jrm0grmqvvk2ce5ksnxcs9ecgtnryt7xg34060uctupg60d02</code>
-** Unconfidential address: <code>ert1qpasxxt9vv6tgfnvgzuuy9e3j9lryg6ha53x9q0</code>
+** Confidential address: <code><lq1qq0r6pegudzm0tzpszelc34qjln4fdxawgwmgnza63wwpzdy6jrm0grmqvvk2ce5ksnxcs9ecgtnryt7xg3406y5ccl0k2glns/code>
+** Unconfidential address: <code>ex1qpasxxt9vv6tgfnvgzuuy9e3j9lryg6hawrval4</code>
 
 This one is a "view descriptor" which has a private blinding key but otherwise public keys:
 
 * View Descriptor: <code>ct(xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#j95xktq7</code>
 ** Descriptor blinding private key: <code>xprv9s21ZrQH143K28NgQ7bHCF61hy9VzwquBZvpzTwXLsbmQLRJ6iV9k2hUBRt5qzmBaSpeMj5LdcsHaXJvM7iFEivPryRcL8irN7Na9p65UUb</code>
-** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
-** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+** Confidential address: <code>lq1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvtk83xqzx62q4</code>
+** Unconfidential address: <code>ex1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyktcafre</code>
 * Non-view Descriptor: <code>ct(xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs,elwpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))#elmfpmp9</code>
 ** Descriptor blinding public key: <code>xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs</code>
-** Confidential address: <code>el1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvq78z9wukacu0</code>
-** Unconfidential address: <code>ert1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyk32h3ur</code>
+** Confidential address: <code>lq1qq2r0pdvcknjpwev96qu9975alzqs78cvsut5ju82t7tv8d645dgmwknpl78t02k2xqgdh9ltmfmpy9ssk7qfvtk83xqzx62q4</code>
+** Unconfidential address: <code>ex1qtfsllr4h4t9rqyxmjl4a5asjzcgt0qyktcafre</code>
 
 The non-view descriptor is the same as the view descriptor except that its private blinding key has been replaced with a public key. Notice that the generated addresses are the same in both cases.
 
@@ -151,13 +151,13 @@ This one is a "view descriptor" using ordinary keys rather than extended ones:
 
 * View Descriptor 2: <code>ct(c25deb86fa11e49d651d7eae27c220ef930fbd86ea023eebfa73e54875647963,elwpkh(021a8fb6bd5a653b021b98a2a785725b8ddacfe3687bc043aa7f4d25d3a48d40b5))#c2kx9zll</code>
 ** Descriptor blinding private key: <code>c25deb86fa11e49d651d7eae27c220ef930fbd86ea023eebfa73e54875647963</code>
-** Confidential address: <code>el1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfyqwa4jj40uffq</code>
-** Unconfidential address: <code>ert1qklrycvkecdanpcpyulgz3c8udvxyck5jkzxddw</code>
+** Confidential address: <code>lq1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfytxax3utlmm46</code>
+** Unconfidential address: <code>ex1qklrycvkecdanpcpyulgz3c8udvxyck5jvsv4j5</code>
 
 * Non-view Descriptor 2: <code>ct(0286fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90,elwpkh(021a8fb6bd5a653b021b98a2a785725b8ddacfe3687bc043aa7f4d25d3a48d40b5))#m5mvyh29</code>
 ** Descriptor blinding public key: <code>0286fc9a38e765d955e9b0bcc18fa9ae81b0c893e2dd1ef5542a9c73780a086b90</code>
-** Confidential address: <code>el1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfyqwa4jj40uffq</code>
-** Unconfidential address: <code>ert1qklrycvkecdanpcpyulgz3c8udvxyck5jkzxddw</code>
+** Confidential address: <code>lq1qq265u4g3k3m3qpyxjwpdrtnm293wuxgvs9xzmzcs2ck0mv5rx23w4d7xfsednsmmxrszfe7s9rs0c6cvf3dfytxax3utlmm46</code>
+** Unconfidential address: <code>ex1qklrycvkecdanpcpyulgz3c8udvxyck5jvsv4j5</code>
 
 Finally, the following are invalid test vectors that should not be parseable:
 

--- a/elip-0151.mediawiki
+++ b/elip-0151.mediawiki
@@ -104,13 +104,13 @@ The following ordinary descriptors yield to the given descriptor blinding keys:
 ** Derived descriptor blinding key: <code>b3baf94d60cf8423cd257283575997a2c00664ced3e8de00f8726703142b1989</code>
 ** Derived confidential descriptor: <code>ct(b3baf94d60cf8423cd257283575997a2c00664ced3e8de00f8726703142b1989,elwpkh(xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8/<0;1>/*))#tu4ggqlv</code>
 ** Derived confidential descriptor (equivalent version): <code>ct(elip151,elwpkh(xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8/<0;1>/*))#m47kvl05</code>
-** First address: <code>el1qqt33kuqusp3amjam96zxg27wvg2ewvl69h3equtck8lk8349vrxt28w2wqel8nstvtmefmexkn9zg5hhku2u7at99v5ee3rda</code>
+** First address: <code>lq1qqv4dksp0dsvrkcgq58ggj2tfjnhnhuteg5f7khv7hrr259690zstu8w2wqel8nstvtmefmexkn9zg5hhku2u7hxcjrl4uq043</code>
 * Test vector 2
 ** Ordinary descriptor: <code>elwpkh(xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8/0/*)#xshkmp3l</code>
 ** Derived descriptor blinding key: <code>de9c5fb624154624146a8aea0489b30f05c720eed6b493b1f3ab63405a11bf37</code>
 ** Derived confidential descriptor: <code>ct(de9c5fb624154624146a8aea0489b30f05c720eed6b493b1f3ab63405a11bf37,elwpkh(xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8/0/*))#34lpke0s</code>
 ** Derived confidential descriptor (equivalent version): <code>ct(elip151,elwpkh(xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8/0/*))#y0su9u33</code>
-** First address: <code>el1qqwv7x220qlm8kwjewuwcdl2c88n202jx4ug7fhjdj3xt25my2zq0w8w2wqel8nstvtmefmexkn9zg5hhku2u7rs2fju6fk4nr</code>
+** First address: <code>lq1qqd5w0l3mev79fpaslhx3v978yjzd9a3srsrcukawlh3zu5rjh55nz8w2wqel8nstvtmefmexkn9zg5hhku2u74uy3m6te46yv</code>
 
 The "first" address specified above is the address at index 0 from the first single descriptor (if multipath).
 


### PR DESCRIPTION
Consistently with the extended pubkey network.

Generated with https://github.com/ElementsProject/elements-miniscript/pull/77