### PR TITLE
readme: add ELIP 202

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -74,6 +74,13 @@ Having an ELIP here does not make it a formally accepted standard until its stat
 | Kilian Rausch
 | Standards Track
 | Active
+|- style="background-color: #ffcfcf"
+| [[elip-0202.mediawiki|202]]
+| Applications
+| Optional sidechain peg-in subsidy and minimum peg-in amount
+| Byron Hambly
+| Standards Track
+| Draft
 |}
 
 <!-- IMPORTANT!  See the instructions at the top of this page, do NOT JUST add BIPs here! -->


### PR DESCRIPTION
Adds ELIP 202 to the table of contents in the readme. 

re #28 